### PR TITLE
docs: Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ Inside the table, we defined the decision logic with:
 1. An indicator of hit policy, `F` in this case meaning the first rule matched will be applied. See [`Hit Policies` section](#hit-policies) for more information.
 2. Two input stubs, `day` and `weather` which are both strings. See [`Input Stubs` section](#input-stubs)
 3. An output stub, `activity` in this case. See [`Output Stubs` section](#output-stubs)
-4. Six rules which take inputs and determine the acitivity output. See [`Rules` section](#rules)
+4. Six rules which take inputs and determine the activity output. See [`Rules` section](#rules)
 5. A friendly expression in each cell of the rules. See [`Expression` section](#expression)
 
 ## Vertical Table
 
-Vertical tables are the same as horinzontal ones. It's just a matter of direction.
+Vertical tables are the same as horizontal ones. It's just a matter of direction.
 The following tables are the same:
 
 ```
@@ -126,10 +126,10 @@ Currently only these types are supported:
 - literal numeric value: integer and float (without scientific notation)
 - literal quoted string in `"`
 - boolean
-- comparation: `>`, `>=`, `<`, `<=`
+- comparison: `>`, `>=`, `<`, `<=`
 - range, e.g. `5..10`
 - nil ("null")
-- list of numeric, string, range, bool, nil or comparation; can be mixed
+- list of numeric, string, range, bool, nil or comparison; can be mixed
 - any ("-")
 
 The following types of expressions are planned:

--- a/guides/code_execution.md
+++ b/guides/code_execution.md
@@ -33,7 +33,7 @@ For example, the following code is not allowed:
 
 ## Variables
 
-We can refer to arbitary variable names as long as are provided in the binding argument of `Tablex.decide/2` or `Tablex/decide/3`. For example:
+We can refer to arbitrary variable names as long as are provided in the binding argument of `Tablex.decide/2` or `Tablex/decide/3`. For example:
 
     iex> table = Tablex.new("""
     ...>   M day_of_week || "Go to Library"  Volunteer  Blogging

--- a/guides/nested_fields.md
+++ b/guides/nested_fields.md
@@ -4,7 +4,7 @@ When working with nested data structures, Tablex allows either checking against 
 
 ## Path
 
-Pathes can be defined with `.` separator. For instance, `path.to.data` which will match `%{path: %{to: data}}` when used in input stubs, or meandeeply merging `%{path: %{to: data}}` into the output when used in output stubs.
+Paths can be defined with `.` separator. For instance, `path.to.data` which will match `%{path: %{to: data}}` when used in input stubs, or meandeeply merging `%{path: %{to: data}}` into the output when used in output stubs.
 
 ## Nested Input Fields
 

--- a/lib/tablex/parser/comparison.ex
+++ b/lib/tablex/parser/comparison.ex
@@ -1,11 +1,11 @@
-defmodule Tablex.Parser.Expression.Comparation do
+defmodule Tablex.Parser.Expression.Comparison do
   @moduledoc false
 
   import NimbleParsec
   import Tablex.Parser.Space
   import Tablex.Parser.Expression.Numeric
 
-  def comparation do
+  def comparison do
     choice([
       string("!="),
       string(">="),
@@ -15,11 +15,11 @@ defmodule Tablex.Parser.Expression.Comparation do
     ])
     |> optional_space()
     |> concat(numeric())
-    |> reduce({__MODULE__, :trans_comparation, []})
+    |> reduce({__MODULE__, :trans_comparison, []})
   end
 
   @doc false
-  def trans_comparation([op, num]) do
+  def trans_comparison([op, num]) do
     {:"#{op}", num}
   end
 end

--- a/lib/tablex/parser/expression.ex
+++ b/lib/tablex/parser/expression.ex
@@ -11,7 +11,7 @@ defmodule Tablex.Parser.Expression do
   import Tablex.Parser.Expression.ImpliedString
   import Tablex.Parser.Expression.QuotedString
   import Tablex.Parser.Expression.Null
-  import Tablex.Parser.Expression.Comparation
+  import Tablex.Parser.Expression.Comparison
 
   def expression do
     choice([
@@ -21,7 +21,7 @@ defmodule Tablex.Parser.Expression do
       numeric(),
       bool(),
       null(),
-      comparation(),
+      comparison(),
       quoted_string(),
       implied_string()
     ])

--- a/lib/tablex/parser/expression/list.ex
+++ b/lib/tablex/parser/expression/list.ex
@@ -5,7 +5,7 @@ defmodule Tablex.Parser.Expression.List do
   import Tablex.Parser.Expression.Range
   import Tablex.Parser.Expression.Numeric
   import Tablex.Parser.Expression.Bool
-  import Tablex.Parser.Expression.Comparation
+  import Tablex.Parser.Expression.Comparison
   import Tablex.Parser.Expression.QuotedString
   import Tablex.Parser.Expression.ImpliedString
   import Tablex.Parser.Expression.Null
@@ -14,7 +14,7 @@ defmodule Tablex.Parser.Expression.List do
   def list do
     choice([
       empty_list(),
-      explict_list(),
+      explicit_list(),
       implied_list()
     ])
   end
@@ -23,7 +23,7 @@ defmodule Tablex.Parser.Expression.List do
     string("[]") |> replace([])
   end
 
-  def explict_list do
+  def explicit_list do
     string("[")
     |> concat(
       choice([
@@ -52,7 +52,7 @@ defmodule Tablex.Parser.Expression.List do
   def list_item do
     choice([
       range(),
-      comparation(),
+      comparison(),
       numeric(),
       bool(),
       null(),
@@ -63,5 +63,5 @@ defmodule Tablex.Parser.Expression.List do
 
   @doc false
   def trans_list(["[", "]"]), do: []
-  def trans_list(["[", pased, "]"]), do: List.wrap(pased)
+  def trans_list(["[", passed, "]"]), do: List.wrap(passed)
 end

--- a/lib/tablex/parser/rule.ex
+++ b/lib/tablex/parser/rule.ex
@@ -33,9 +33,9 @@ defmodule Tablex.Parser.Rule do
     |> space()
     |> repeat_while(
       concat(expression(), space()),
-      {__MODULE__, :not_seperator, []}
+      {__MODULE__, :not_separator, []}
     )
-    |> concat(seperator())
+    |> concat(separator())
     |> space()
     |> concat(
       output_expression()
@@ -54,13 +54,13 @@ defmodule Tablex.Parser.Rule do
   end
 
   @doc false
-  def not_seperator(<<"|| ", _::binary>>, context, _, _),
+  def not_separator(<<"|| ", _::binary>>, context, _, _),
     do: {:halt, context}
 
-  def not_seperator(_rest, context, _, _),
+  def not_separator(_rest, context, _, _),
     do: {:cont, context}
 
-  def seperator do
+  def separator do
     string("||") |> replace(:||)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -70,7 +70,7 @@ defmodule Tablex.MixProject do
         border-color: #DDD;
       }
 
-      table.tablex.horinzontal th {
+      table.tablex.horizontal th {
         border-bottom: double;
         font-weight: bold;
       }

--- a/test/tablex/parser/expression_test.exs
+++ b/test/tablex/parser/expression_test.exs
@@ -114,7 +114,7 @@ defmodule Tablex.Parser.ExpressionTest do
     end
   end
 
-  describe "Parsing comparations" do
+  describe "Parsing comparisons" do
     test "works with `>`" do
       assert_parse(">  1", {:>, 1})
       assert_parse("> 1", {:>, 1})


### PR DESCRIPTION
Found via `typos --format brief`