### PR TITLE
chore: ci tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,4 @@ jobs:
           elixir-version: ${{matrix.elixir}}
       - run: mix deps.get
       - run: mix compile --warnings-as-errors
+      - run: mix test --slowest 5


### PR DESCRIPTION
@qhwa @kianmeng Following up from the CI compile PR, here we run tests.

Tests are currently failing due to long sigil - I have a PR also for this which will follow.

I can use the library, just cannot run tests yet.  Many thanks!