### PR TITLE
fix: sigil single char

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,4 @@ jobs:
           elixir-version: ${{matrix.elixir}}
       - run: mix deps.get
       - run: mix compile --warnings-as-errors
+      - run: mix test --slowest 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: ci
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Tablex on Elixir ${{matrix.elixir}} (Erlang/OTP ${{matrix.otp}})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        otp: ['25.3']
+        elixir: ['1.13.4', '1.14.5', 'v1.15.0-rc.1']
+    steps:
+      - uses: actions/checkout@v3
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{matrix.otp}}
+          elixir-version: ${{matrix.elixir}}
+      - run: mix deps.get
+      - run: mix compile --warnings-as-errors

--- a/examples.exs
+++ b/examples.exs
@@ -1,6 +1,6 @@
 import Tablex
 
-sheet = ~RULES"""
+sheet = ~t"""
 F   Age (integer)  Years_of_service  || Holidays (float)
 1   >=60           -                 || 3
 2   45..59         <30               || 2

--- a/lib/tablex.ex
+++ b/lib/tablex.ex
@@ -25,11 +25,12 @@ defmodule Tablex do
   end
 
   @doc """
-  The same as `new/2`.
+  Same as `new/2`.
 
   ## Example
+      import Tablex
 
-      ~RULES\"""
+      ~t\"""
       F  value  || color
       1  >90    || red
       2  80..90 || orange
@@ -37,8 +38,8 @@ defmodule Tablex do
       4  <20    || blue
       \"""
   """
-  @spec sigil_RULES(String.t(), keyword()) :: Tablex.Table.t()
-  def sigil_RULES(content, opts) do
+  @spec sigil_t(String.t(), keyword()) :: Tablex.Table.t()
+  def sigil_t(content, opts) do
     new(content, opts)
   end
 end

--- a/test/tablex/code_generate_test.exs
+++ b/test/tablex/code_generate_test.exs
@@ -9,7 +9,7 @@ defmodule Tablex.CodeGenerateTest do
 
   test "it works" do
     table =
-      ~RULES"""
+      ~t"""
       F GPA       StandardizedTestScores ExtracurricularActivities RecommendationLetters || AdmissionDecision
       1 >=3.5     >1300                  >=2                       >=2                   || Accepted
       2 <3.5      1000..1300             1..2                      1..2                  || Waitlisted
@@ -43,7 +43,7 @@ defmodule Tablex.CodeGenerateTest do
 
   test "it works with lists" do
     table =
-      ~RULES"""
+      ~t"""
       F Day                  || OpenHours
       1 Mon,Tue,Wed,Thu,Fri  || "10:00 - 20:00"
       2 Sat                  || "10:00 - 18:00"
@@ -57,7 +57,7 @@ defmodule Tablex.CodeGenerateTest do
 
   test "it works with a complicated list" do
     table =
-      ~RULES"""
+      ~t"""
       F OrderValue  ShippingDestination     ShippingWeight || ShippingOption
       1 >=100,97    domestic                -              || "Free Shipping"
       2 -           domestic,international  <=5            || "Standard Shipping"
@@ -99,7 +99,7 @@ defmodule Tablex.CodeGenerateTest do
   describe "Generating code with `collect` hit policy tables" do
     test "works with simplest collect tables" do
       table =
-        ~RULES"""
+        ~t"""
         C || grade program
         1 || 1     science
         2 || 2     "visual art"
@@ -119,7 +119,7 @@ defmodule Tablex.CodeGenerateTest do
 
     test "works with inputs" do
       table =
-        ~RULES"""
+        ~t"""
         C grade || program
         1 1     || science
         2 2     || "visual art"
@@ -137,7 +137,7 @@ defmodule Tablex.CodeGenerateTest do
   describe "Generating code from a table with `merge` hit policy" do
     test "works" do
       table =
-        ~RULES"""
+        ~t"""
         M   Continent  Country  Province || Feature1 Feature2
         1   Asia       Thailand -        || true     true
         2   America    Canada   BC,ON    || -        true
@@ -164,7 +164,7 @@ defmodule Tablex.CodeGenerateTest do
   describe "Generating code from a table with `reverse_merge` hit policy" do
     test "works" do
       table =
-        ~RULES"""
+        ~t"""
         R   Continent  Country  Province || Feature1 Feature2
         1   Europe     -        -        || false    true
         2   Europe     France   -        || true     -


### PR DESCRIPTION
fix: sigil must be single char

Suggest we use ~t for "table" as it is not used in standard Elixir.
* ~R for "Rules" is used by `Regex`
* ~T is used for `Time`

Fixes:

    invalid sigil delimiter: "U" (column 9, code point U+0055)

@qhwa @kianmeng 