### PR TITLE
Disable long sigil for Elixir before 1.15.

### DIFF
--- a/lib/tablex.ex
+++ b/lib/tablex.ex
@@ -24,21 +24,23 @@ defmodule Tablex do
     Tablex.Parser.parse(content, opts)
   end
 
-  @doc """
-  The same as `new/2`.
+  if Version.compare(System.version(), "1.15.0-dev") in [:eq, :gt] do
+    @doc """
+    The same as `new/2`.
 
-  ## Example
+    ## Example
 
-      ~RULES\"""
-      F  value  || color
-      1  >90    || red
-      2  80..90 || orange
-      3  20..79 || green
-      4  <20    || blue
-      \"""
-  """
-  @spec sigil_RULES(String.t(), keyword()) :: Tablex.Table.t()
-  def sigil_RULES(content, opts) do
-    new(content, opts)
+        ~RULES\"""
+        F  value  || color
+        1  >90    || red
+        2  80..90 || orange
+        3  20..79 || green
+        4  <20    || blue
+        \"""
+    """
+    @spec sigil_RULES(String.t(), keyword()) :: Tablex.Table.t()
+    def sigil_RULES(content, opts) do
+      new(content, opts)
+    end
   end
 end

--- a/test/tablex/code_generate_test.exs
+++ b/test/tablex/code_generate_test.exs
@@ -3,20 +3,19 @@ defmodule Tablex.CodeGenerateTest do
 
   use ExUnit.Case
   import CodeGenerate
-  import Tablex
 
   doctest CodeGenerate
 
   test "it works" do
     table =
-      ~RULES"""
+      Tablex.new("""
       F GPA       StandardizedTestScores ExtracurricularActivities RecommendationLetters || AdmissionDecision
       1 >=3.5     >1300                  >=2                       >=2                   || Accepted
       2 <3.5      1000..1300             1..2                      1..2                  || Waitlisted
       3 <3.0      -                      -                         -                     || Denied
       4 -         <1000                  >=2                       >=2                   || "Further Review"
       5 -         -                      -                         -                     || Denied
-      """
+      """)
 
     assert_eval(
       table,
@@ -43,12 +42,12 @@ defmodule Tablex.CodeGenerateTest do
 
   test "it works with lists" do
     table =
-      ~RULES"""
+      Tablex.new("""
       F Day                  || OpenHours
       1 Mon,Tue,Wed,Thu,Fri  || "10:00 - 20:00"
       2 Sat                  || "10:00 - 18:00"
       3 Sun                  || "12:00 - 18:00"
-      """
+      """)
 
     assert_eval(table, [day: "Mon"], %{open_hours: "10:00 - 20:00"})
     assert_eval(table, [day: "Sat"], %{open_hours: "10:00 - 18:00"})
@@ -57,13 +56,13 @@ defmodule Tablex.CodeGenerateTest do
 
   test "it works with a complicated list" do
     table =
-      ~RULES"""
+      Tablex.new("""
       F OrderValue  ShippingDestination     ShippingWeight || ShippingOption
       1 >=100,97    domestic                -              || "Free Shipping"
       2 -           domestic,international  <=5            || "Standard Shipping"
       3 -           international           >5,null        || "Expedited Shipping"
       4 -           space                   -              || "Rocket Shipping"
-      """
+      """)
 
     assert_eval(
       table,
@@ -99,12 +98,12 @@ defmodule Tablex.CodeGenerateTest do
   describe "Generating code with `collect` hit policy tables" do
     test "works with simplest collect tables" do
       table =
-        ~RULES"""
+        Tablex.new("""
         C || grade program
         1 || 1     science
         2 || 2     "visual art"
         3 || 3     music,"visual art"
-        """
+        """)
 
       assert_eval(
         table,
@@ -119,12 +118,12 @@ defmodule Tablex.CodeGenerateTest do
 
     test "works with inputs" do
       table =
-        ~RULES"""
+        Tablex.new("""
         C grade || program
         1 1     || science
         2 2     || "visual art"
         3 1..3  || music
-        """
+        """)
 
       assert_eval(
         table,
@@ -137,7 +136,7 @@ defmodule Tablex.CodeGenerateTest do
   describe "Generating code from a table with `merge` hit policy" do
     test "works" do
       table =
-        ~RULES"""
+        Tablex.new("""
         M   Continent  Country  Province || Feature1 Feature2
         1   Asia       Thailand -        || true     true
         2   America    Canada   BC,ON    || -        true
@@ -145,7 +144,7 @@ defmodule Tablex.CodeGenerateTest do
         4   America    US       -        || false    false
         5   Europe     France   -        || true     -
         6   Europe     -        -        || false    true
-        """
+        """)
 
       assert_eval(
         table,
@@ -164,7 +163,7 @@ defmodule Tablex.CodeGenerateTest do
   describe "Generating code from a table with `reverse_merge` hit policy" do
     test "works" do
       table =
-        ~RULES"""
+        Tablex.new("""
         R   Continent  Country  Province || Feature1 Feature2
         1   Europe     -        -        || false    true
         2   Europe     France   -        || true     -
@@ -172,7 +171,7 @@ defmodule Tablex.CodeGenerateTest do
         4   America    Canada   -        || true     false
         5   America    Canada   BC,ON    || -        true
         6   Asia       Thailand -        || true     true
-        """
+        """)
 
       assert_eval(
         table,


### PR DESCRIPTION
Since long sigils are only supported after Elixir 1.15, this is blocking the testing on old versions. The fix is to disable it on Elixir before 1.15.