### PR TITLE
 Fix testing on Elixir 1.14.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,7 @@ defmodule Tablex.MixProject do
       app: :tablex,
       version: "0.1.1-alpha.3",
       elixir: "~> 1.11",
+      elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       docs: docs(),
@@ -179,4 +180,8 @@ defmodule Tablex.MixProject do
       }
     ]
   end
+
+  # Specifies which paths to compile per environment
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 end

--- a/test/support/maybe_doctest_file.ex
+++ b/test/support/maybe_doctest_file.ex
@@ -1,0 +1,15 @@
+defmodule DoctestFile do
+  Code.ensure_loaded!(ExUnit.DocTest)
+
+  unless macro_exported?(ExUnit.DocTest, :doctest_file, 1) do
+    require Logger
+
+    def doctest_file(file) do
+      Logger.warning(
+        "`doctest_file(#{inspect(file)})` is skipped because we're running on Elixir #{System.version()}."
+      )
+
+      :ok
+    end
+  end
+end

--- a/test/tablex/code_execution_test.exs
+++ b/test/tablex/code_execution_test.exs
@@ -1,5 +1,7 @@
 defmodule Tablex.CodeExecutionTest do
   use ExUnit.Case
+  import DoctestFile
+
   doctest_file("guides/code_execution.md")
 
   describe "Exuecting code in an output field" do

--- a/test/tablex/informative_row_test.exs
+++ b/test/tablex/informative_row_test.exs
@@ -1,6 +1,8 @@
 defmodule Tablex.InformativeRowTest do
   alias Tablex.Table
   use ExUnit.Case
+  import DoctestFile
+
   doctest_file("guides/informative_row.md")
 
   describe "Informative row" do

--- a/test/tablex/nested_test.exs
+++ b/test/tablex/nested_test.exs
@@ -1,5 +1,7 @@
 defmodule Tablex.NestedTest do
   use ExUnit.Case
+  import DoctestFile
+
   doctest_file("guides/nested_fields.md")
 
   describe "Nested output definition" do
@@ -41,8 +43,7 @@ defmodule Tablex.NestedTest do
         2 -    || F
         """)
 
-      code =
-        Tablex.CodeGenerate.generate(table)
+      code = Tablex.CodeGenerate.generate(table)
 
       assert {%{hit: false}, _} = Code.eval_string(code, a: %{b: 10})
       assert {%{hit: true}, _} = Code.eval_string(code, a: %{b: 9})
@@ -56,8 +57,7 @@ defmodule Tablex.NestedTest do
         2 -      || F
         """)
 
-      code =
-        Tablex.CodeGenerate.generate(table)
+      code = Tablex.CodeGenerate.generate(table)
 
       assert {%{hit: false}, _} = Code.eval_string(code, a: %{b: %{c: 10}})
       assert {%{hit: true}, _} = Code.eval_string(code, a: %{b: %{c: 9}})
@@ -72,8 +72,7 @@ defmodule Tablex.NestedTest do
         2 -                   || true
         """)
 
-      code =
-        Tablex.CodeGenerate.generate(table)
+      code = Tablex.CodeGenerate.generate(table)
 
       assert {%{enabled: false}, _} = Code.eval_string(code, quest: %{brand: %{id: 602}})
     end

--- a/test/tablex_test.exs
+++ b/test/tablex_test.exs
@@ -1,5 +1,6 @@
 defmodule TablexTest do
   use ExUnit.Case
+  import DoctestFile
 
   doctest Tablex
   doctest_file("README.md")


### PR DESCRIPTION
This PR fixes `doctest_file` import on Elixir before 1.15 so that [CI](https://github.com/elixir-tablex/tablex/pull/17) can pass.