### PR TITLE
Add support for structs as decision arguments

### DIFF
--- a/lib/tablex/decider.ex
+++ b/lib/tablex/decider.ex
@@ -57,9 +57,20 @@ defmodule Tablex.Decider do
   defp context(inputs, args) do
     for %{name: name, path: path} <- inputs, into: %{} do
       path = path ++ [name]
-      {path, get_in(args, path)}
+      {path, safe_get_in(args, path)}
     end
     |> flatten_path()
+  end
+
+  defp safe_get_in(nil, _any), do: nil
+  defp safe_get_in(value, []), do: value
+
+  defp safe_get_in(args, [key | rest]) do
+    case args do
+      %{^key => value} -> safe_get_in(value, rest)
+      keyword when is_list(keyword) -> safe_get_in(args[key], rest)
+      _other -> safe_get_in(get_in(args, [key]), rest)
+    end
   end
 
   defp rules(%Table{rules: rules, inputs: inputs, outputs: outputs}) do

--- a/test/tablex/nested_test.exs
+++ b/test/tablex/nested_test.exs
@@ -18,6 +18,26 @@ defmodule Tablex.NestedTest do
                %{a: %{b: 3, c: 4}}
              ]
     end
+
+    defmodule StructA do
+      defstruct [:a]
+    end
+
+    defmodule StructB do
+      defstruct [:b]
+    end
+
+    test "works with structs" do
+      table =
+        Tablex.new("""
+        F a.b  || hit
+        1 <10  || T
+        2 -    || F
+        """)
+
+      assert %{hit: false} = Tablex.decide(table, %StructA{a: %StructB{b: 10}})
+      assert %{hit: true} = Tablex.decide(table, %StructA{a: %StructB{b: 9}})
+    end
   end
 
   describe "Nested input definition" do


### PR DESCRIPTION
We're experimenting with the library and we'd like to use it with Ecto structs.

Rather than having to convert all struct recursively to maps, I propose to handle this in the library while building the context.