### PR TITLE
Fix a bug in formatting string values.

### DIFF
--- a/lib/tablex/formatter/value.ex
+++ b/lib/tablex/formatter/value.ex
@@ -34,10 +34,12 @@ defmodule Tablex.Formatter.Value do
   end
 
   defp maybe_quoted(str) do
-    if String.contains?(str, " ") do
-      inspect(str)
-    else
-      str
+    case Tablex.Parser.expr(str) do
+      {:ok, [^str], "", _, _, _} ->
+        str
+
+      _ ->
+        inspect(str)
     end
   end
 end

--- a/test/tablex/formatter_test.exs
+++ b/test/tablex/formatter_test.exs
@@ -174,6 +174,18 @@ defmodule Tablex.FormatterTest do
     end
   end
 
+  describe "Formatting ambitional strings" do
+    test "works" do
+      table =
+        Tablex.new("""
+        C || value
+        1 || "1983-04-01"
+        """)
+
+      assert_format(table)
+    end
+  end
+
   defp assert_format(table) do
     # table |> Formatter.to_s() |> IO.puts()
     assert table |> Formatter.to_s() |> Tablex.new() == fix_ids(table)


### PR DESCRIPTION
This PR improves the formatter, fixing a bug that causes some string values such as `"2044:198::ab"` not to be correctly formatted as strings.