### PR TITLE
Stop formatting code when generating Elixir code to improve the performance

### DIFF
--- a/lib/tablex/code_generate.ex
+++ b/lib/tablex/code_generate.ex
@@ -85,8 +85,6 @@ defmodule Tablex.CodeGenerate do
       #{rule_clauses(table) |> Enum.join("\n")}
     end
     """
-    |> Code.format_string!()
-    |> IO.iodata_to_binary()
   end
 
   def generate(%Table{hit_policy: :collect, rules: rules, inputs: [], outputs: out_def}) do


### PR DESCRIPTION
Formatting code consumes too much memory, so we removed it from the steps.

One can always format the code after getting the generated code.