### PR TITLE
chore: Improve the code generated.

### DIFF
--- a/lib/tablex/code_generate.ex
+++ b/lib/tablex/code_generate.ex
@@ -149,7 +149,7 @@ defmodule Tablex.CodeGenerate do
       clauses,
       "]\n",
       "|> Enum.reduce_while(",
-      inspect(empty),
+      i(empty),
       """
       , fn rule_fn, acc ->
         case rule_fn.(binding) do
@@ -276,15 +276,15 @@ defmodule Tablex.CodeGenerate do
   end
 
   defp pattern_guard(literal, _) when is_literal(literal) do
-    inspect(literal)
+    i(literal)
   end
 
   defp join_literal_pattern_guard(var_name, [v]) do
-    [var_name, " == ", inspect(v)]
+    [var_name, " == ", i(v)]
   end
 
   defp join_literal_pattern_guard(var_name, list) do
-    [var_name, " in ", inspect(list, charlists: :as_lists)]
+    [var_name, " in ", i(list)]
   end
 
   defp join_pattern_guard(var_name, list, %{name: name, path: path}) when is_list(list) do
@@ -328,7 +328,7 @@ defmodule Tablex.CodeGenerate do
   end
 
   defp to_code(v) do
-    inspect(v)
+    i(v)
   end
 
   defp rule_output_values(outputs) do
@@ -342,7 +342,7 @@ defmodule Tablex.CodeGenerate do
   end
 
   defp output_pathes(outputs) do
-    for %{name: name, path: path} <- outputs, do: inspect(path ++ [name])
+    for %{name: name, path: path} <- outputs, do: i(path ++ [name])
   end
 
   defp to_nested_pattern("_", _) do
@@ -353,5 +353,9 @@ defmodule Tablex.CodeGenerate do
     %{tl(path ++ [name]) => {:code, flat_pattern}}
     |> DeepMap.flatten()
     |> to_code()
+  end
+
+  defp i(v) do
+    inspect(v, limit: :infinity, char_lists: :as_lists)
   end
 end

--- a/test/tablex/code_execution_test.exs
+++ b/test/tablex/code_execution_test.exs
@@ -54,6 +54,20 @@ defmodule Tablex.CodeExecutionTest do
       assert %{go_to_library: true, volunteer: false, blogging: true} ==
                run(table, day_of_week: 1, week_of_month: 4)
     end
+
+    test "works with `reverse_merge` hit policy" do
+      store_ids = 1..1000 |> Enum.map_join(",", &"#{&1}")
+
+      table =
+        Tablex.new("""
+        R store_id || active
+        1 - || false
+        2 [#{store_ids}] || true
+        """)
+
+      assert %{active: true} = run(table, store_id: :rand.uniform(999) + 1)
+      assert %{active: false} = run(table, store_id: "foo")
+    end
   end
 
   defp run(table, args) do


### PR DESCRIPTION
This branch fixes a performance issue that consumes lots of memory when generating Elixir code from a Tablex table.

The changes are:

- Stop expanding rules before compiling
- Stop using `Code.format_string!/1`, which is the root cause of high memory usage.
- Use iodata instead of string templating.