### PR TITLE
Keep variable name cases.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ make maitaining domain rules easy.
 Let's assume we decide what to do everyday based on day of week and the weather,
 as the following table indicates:
 
-<table class="tablex horizontal"><colgroup> <col span="1" class="rule-number"> <col span="2" class="input"> <col span="1" class="output"> </colgroup> <thead><tr><th class="hit-policy hit-policy-F"></th><th class="input">Day (string)</th><th class="input">Weather (string)</th><th class="output">Activity</th></tr></thead><tbody><tr><td class="rule-number">1</td><td rowspan="2" class="input">Monday, Tuesday, Wednesday, Thursday</td><td class="input">rainy</td><td class="output">read</td></tr><tr><td class="rule-number">2</td><td class="input">-</td><td class="output">read, walk</td></tr><tr><td class="rule-number">3</td><td rowspan="2" class="input">Friday</td><td class="input">sunny</td><td class="output">soccer</td></tr><tr><td class="rule-number">4</td><td class="input">-</td><td class="output">swim</td></tr><tr><td class="rule-number">5</td><td class="input">Saturday</td><td class="input">-</td><td class="output">watch movie, games</td></tr><tr><td class="rule-number">6</td><td class="input">Sunday</td><td class="input">-</td><td class="output">null</td></tr></tbody></table>
+<table class="tablex horizontal"><colgroup> <col span="1" class="rule-number"> <col span="2" class="input"> <col span="1" class="output"> </colgroup> <thead><tr><th class="hit-policy hit-policy-F"></th><th class="input">day (string)</th><th class="input">weather (string)</th><th class="output">activity</th></tr></thead><tbody><tr><td class="rule-number">1</td><td rowspan="2" class="input">Monday, Tuesday, Wednesday, Thursday</td><td class="input">rainy</td><td class="output">read</td></tr><tr><td class="rule-number">2</td><td class="input">-</td><td class="output">read, walk</td></tr><tr><td class="rule-number">3</td><td rowspan="2" class="input">Friday</td><td class="input">sunny</td><td class="output">soccer</td></tr><tr><td class="rule-number">4</td><td class="input">-</td><td class="output">swim</td></tr><tr><td class="rule-number">5</td><td class="input">Saturday</td><td class="input">-</td><td class="output">watch movie, games</td></tr><tr><td class="rule-number">6</td><td class="input">Sunday</td><td class="input">-</td><td class="output">null</td></tr></tbody></table>
 
 We can use a similar tabular form of the code in an Elixir program:
 
 ``` elixir
 ...> plans = Tablex.new("""
-...> F   Day (string)                         Weather (string) || Activity
+...> F   day (string)                         weather (string) || activity
 ...> 1   Monday,Tuesday,Wednesday,Thursday    rainy            || read
 ...> 2   Monday,Tuesday,Wednesday,Thursday    -                || read,walk
 ...> 3   Friday                               sunny            || soccer
@@ -50,7 +50,7 @@ Vertical tables are the same as horizontal ones. It's just a matter of direction
 The following tables are the same:
 
 ```
-F "Product Category" "Competitor Pricing"     "Product Features" || "Launch Decision" Reasoning
+F product_category   competitor_pricing       product_features   || launch_decision   reasoning
 1 Electronics        "Higher than Competitor" "More Features"    || Launch            "Competitive Advantage"
 2 Electronics        "Lower than Competitor"  "Same Features"    || Launch            "Price Advantage"
 3 Fashion            "Same as Competitor"     "New Features"     || "Do Not Launch"   "Lack of Differentiation"
@@ -61,12 +61,12 @@ F "Product Category" "Competitor Pricing"     "Product Features" || "Launch Deci
 ```
 ====
 F                    || 1                        2                       3
-"Product Category"   || Electronics              Electronics             Fashion
-"Competitor Pricing" || "Higher than Competitor" "Lower than Competitor" "Same as Competitor"
-"Product Features"   || "More Features"          "Same Features"         "New Features"
+product_category     || Electronics              Electronics             Fashion
+competitor_pricing   || "Higher than Competitor" "Lower than Competitor" "Same as Competitor"
+product_features     || "More Features"          "Same Features"         "New Features"
 ====
-"Launch Decision"    || Launch                   Launch                  "Do Not Launch"
-Reasoning            || "Competitive Advantage"  "Price Advantage"       "Lack of Differentiation"
+launch_decision      || Launch                   Launch                  "Do Not Launch"
+reasoning            || "Competitive Advantage"  "Price Advantage"       "Lack of Differentiation"
 ```
 
 <table class="tablex vertical"><tbody><tr><th class="hit-policy hit-policy-F">F</th><th class="rule-number">1</th><th class="rule-number">2</th><th class="rule-number">3</th></tr></tbody><tbody><tr><th class="input">Product Category</th><td colspan="2"><span class="tbx-exp-string">Electronics</span></td><td><span class="tbx-exp-string">Fashion</span></td></tr><tr><th class="input">Competitor Pricing</th><td><span class="tbx-exp-string">Higher than Competitor</span></td><td><span class="tbx-exp-string">Lower than Competitor</span></td><td><span class="tbx-exp-string">Same as Competitor</span></td></tr><tr><th class="input">Product Features</th><td><span class="tbx-exp-string">More Features</span></td><td><span class="tbx-exp-string">Same Features</span></td><td><span class="tbx-exp-string">New Features</span></td></tr></tbody><tfoot><tr><th class="output">Launch Decision</th><td><span class="tbx-exp-string">Launch</span></td><td><span class="tbx-exp-string">Launch</span></td><td><span class="tbx-exp-string">Do Not Launch</span></td></tr><tr><th class="output">Reasoning</th><td><span class="tbx-exp-string">Competitive Advantage</span></td><td><span class="tbx-exp-string">Price Advantage</span></td><td><span class="tbx-exp-string">Lack of Differentiation</span></td></tr></tfoot></table>
@@ -154,7 +154,7 @@ Examples:
 
 ``` elixir
 iex> table = Tablex.new("""
-...> F   Age (integer)  || f (float)
+...> F   age (integer)  || f (float)
 ...> 1   > 60           || 3.0
 ...> 2   50..60         || 2.5
 ...> 3   31..49         || 2.0
@@ -177,7 +177,7 @@ iex> Tablex.decide(table, age: 1)
 
 ``` elixir
 iex> table = Tablex.new("""
-...> F   Age (integer)  "Years of Service"  || Holidays (integer)
+...> F   age (integer)  years_of_service    || holidays (integer)
 ...> 1   >=60           -                   || 3
 ...> 2   45..59         <30                 || 2
 ...> 3   -              >=30                || 22
@@ -202,7 +202,7 @@ Here's an example of `collect` hit policy:
 
 ``` elixir
 iex> table = Tablex.new("""
-...> C   OrderAmount    Membership       || Discount
+...> C   order_amount   membership       || discount
 ...> 1   >=100          false            || "Free cupcake"
 ...> 2   >=100          true             || "Free icecream"
 ...> 3   -              true             || "20% OFF"
@@ -223,7 +223,7 @@ Collect policy can work without any input:
 
 ``` elixir
 iex> table = Tablex.new("""
-...> C || Country         FeatureVersion
+...> C || country         feature_version
 ...> 1 || "New Zealand"   3
 ...> 2 || "Japan"         2
 ...> 3 || "Brazil"        2
@@ -240,7 +240,7 @@ Here's an example of `merge` hit policy:
 
 ``` elixir
 iex> table = Tablex.new("""
-...> M   Continent  Country  Province || Feature1 Feature2
+...> M   continent  country  province || feature1 feature2
 ...> 1   Asia       Thailand -        || true     true
 ...> 2   America    Canada   BC,ON    || -        true
 ...> 3   America    Canada   -        || true     false
@@ -271,7 +271,7 @@ The `reverse_merge` works the same as `merge` but the rule ordering is reversed:
 
 ``` elixir
 iex> table = Tablex.new("""
-...> R   Continent  Country  Province || Feature1 Feature2
+...> R   continent  country  province || feature1 feature2
 ...> 1   Europe     -        -        || false    true
 ...> 2   Europe     France   -        || true     -
 ...> 3   America    US       -        || false    false
@@ -301,10 +301,10 @@ It is feasible to generate Elixir code from a table with `Tablex.CodeGenerate.ge
 
 ``` elixir
 table = """
-F CreditScore EmploymentStatus Debt-to-Income-Ratio || Action
-1 700         employed         <0.43                || Approved
-2 700         unemployed       -                    || "Further Review"
-3 <=700       -                -                    || Denied
+F credit_score employment_status debt_to_income_ratio || action
+1 700          employed          <0.43                || Approved
+2 700          unemployed        -                    || "Further Review"
+3 <=700        -                 -                    || Denied
 """
 
 Tablex.CodeGenerate.generate(table)

--- a/guides/code_execution.md
+++ b/guides/code_execution.md
@@ -36,10 +36,10 @@ For example, the following code is not allowed:
 We can refer to arbitrary variable names as long as are provided in the binding argument of `Tablex.decide/2` or `Tablex/decide/3`. For example:
 
     iex> table = Tablex.new("""
-    ...>   M day_of_week || "Go to Library"  Volunteer  Blogging
-    ...>   1 1           || T                -          -
-    ...>   2 2           || F                T          -
-    ...>   3 -           || F                F          `week_of_month == 4`
+    ...>   M day_of_week || go_to_library volunteer blogging
+    ...>   1 1           || T             -         -
+    ...>   2 2           || F             T         -
+    ...>   3 -           || F             F         `week_of_month == 4`
     ...>   """)
     ...>
     ...> Tablex.decide(table, day_of_week: 1, week_of_month: 4)

--- a/guides/informative_row.md
+++ b/guides/informative_row.md
@@ -16,7 +16,7 @@ or not specified (`-`).
 
 ``` elixir
 iex> table = Tablex.new("""
-...>   F Symptoms     "Test Results"                            "Medical History"                || Treatment Medication   Follow-up
+...>   F symptoms     test_results                              medical_history                  || treatment medication   follow_up
 ...>     (string)     (string, either NORMAL or ABNORMAL)       (string)                         || (string)  (string)     (integer, in weeks)
 ...>   1 fever,cough  NORMAL                                    "No Allergies"                   || Rest      OTC          2
 ...>   2 "Chest Pain" ABNORMAL                                  ECG,"Family Hx of Heart Disease" || Hospital  Prescription 1
@@ -39,7 +39,7 @@ In case you want to skip some field(s), `"-"` can be used, as:
 
 ``` elixir
 iex> table = Tablex.new("""
-...>   F "Customer Segment" "Purchase Frequency"  || "Campaign Type" Discount   "Email Frequency"
+...>   F customer_segment   purchase_frequency    || campaign_type   discount   email_frequency
 ...>     -                  (integer, times/year) || -               -          -
 ...>   1 Loyal              >8                    || Personalized    "20%"      Monthly
 ...>   2 Occasional         2..8                  || Seasonal        "10%"      Quarterly

--- a/guides/nested_fields.md
+++ b/guides/nested_fields.md
@@ -39,7 +39,7 @@ Following is an example of using nested output stubs in a table.
 
 ``` elixir
 iex> table = Tablex.new("""
-...>   M "Car Size" "Rental Duration"  "Miles Driven"    || price.base      price.extra_mileage_fee  price.insurance_fee
+...>   M car_size rental_duration miles_driven || price.base      price.extra_mileage_fee  price.insurance_fee
 ...>     -          (number, in days)  (number, per day) || (number, $/day) (number, $/mile)         (number, $/day)
 ...>   1 compact    <=3                <=100             || 50              0.25                     15
 ...>   2 mid_size   4..7               101..200          || 70              0.30                     -

--- a/lib/tablex/parser/variable.ex
+++ b/lib/tablex/parser/variable.ex
@@ -98,8 +98,6 @@ defmodule Tablex.Parser.Variable do
         t
         |> String.trim()
         |> String.replace(["-", " "], "_")
-        |> Macro.underscore()
-        |> String.replace(~r/_+/, "_")
         |> String.to_atom()
       end)
       |> Enum.reverse()

--- a/test/tablex/code_execution_test.exs
+++ b/test/tablex/code_execution_test.exs
@@ -42,7 +42,7 @@ defmodule Tablex.CodeExecutionTest do
     test "works with `merge` hit policy" do
       table =
         Tablex.new("""
-        M day_of_week || "Go to Library"  Volunteer  Blogging
+        M day_of_week || go_to_library volunteer  blogging
         1 1           || T                -          -
         2 2           || F                T          -
         3 -           || F                F          `week_of_month == 4`

--- a/test/tablex/code_generate_test.exs
+++ b/test/tablex/code_generate_test.exs
@@ -9,12 +9,12 @@ defmodule Tablex.CodeGenerateTest do
   test "it works" do
     table =
       Tablex.new("""
-      F GPA       StandardizedTestScores ExtracurricularActivities RecommendationLetters || AdmissionDecision
-      1 >=3.5     >1300                  >=2                       >=2                   || Accepted
-      2 <3.5      1000..1300             1..2                      1..2                  || Waitlisted
-      3 <3.0      -                      -                         -                     || Denied
-      4 -         <1000                  >=2                       >=2                   || "Further Review"
-      5 -         -                      -                         -                     || Denied
+      F gpa       standardized_test_scores extracurricular_activities recommendation_letters || admission_decision
+      1 >=3.5     >1300                    >=2                        >=2                    || Accepted
+      2 <3.5      1000..1300               1..2                       1..2                   || Waitlisted
+      3 <3.0      -                        -                          -                      || Denied
+      4 -         <1000                    >=2                        >=2                    || "Further Review"
+      5 -         -                        -                          -                      || Denied
       """)
 
     assert_eval(
@@ -43,7 +43,7 @@ defmodule Tablex.CodeGenerateTest do
   test "it works with lists" do
     table =
       Tablex.new("""
-      F Day                  || OpenHours
+      F day                  || open_hours
       1 Mon,Tue,Wed,Thu,Fri  || "10:00 - 20:00"
       2 Sat                  || "10:00 - 18:00"
       3 Sun                  || "12:00 - 18:00"
@@ -57,11 +57,11 @@ defmodule Tablex.CodeGenerateTest do
   test "it works with a complicated list" do
     table =
       Tablex.new("""
-      F OrderValue  ShippingDestination     ShippingWeight || ShippingOption
-      1 >=100,97    domestic                -              || "Free Shipping"
-      2 -           domestic,international  <=5            || "Standard Shipping"
-      3 -           international           >5,null        || "Expedited Shipping"
-      4 -           space                   -              || "Rocket Shipping"
+      F order_value  shipping_destination     shipping_weight || shipping_option
+      1 >=100,97     domestic                 -               || "Free Shipping"
+      2 -            domestic,international   <=5             || "Standard Shipping"
+      3 -            international            >5,null         || "Expedited Shipping"
+      4 -            space                    -               || "Rocket Shipping"
       """)
 
     assert_eval(
@@ -137,7 +137,7 @@ defmodule Tablex.CodeGenerateTest do
     test "works" do
       table =
         Tablex.new("""
-        M   Continent  Country  Province || Feature1 Feature2
+        M   continent  country  province || feature1 feature2
         1   Asia       Thailand -        || true     true
         2   America    Canada   BC,ON    || -        true
         3   America    Canada   -        || true     false
@@ -164,7 +164,7 @@ defmodule Tablex.CodeGenerateTest do
     test "works" do
       table =
         Tablex.new("""
-        R   Continent  Country  Province || Feature1 Feature2
+        R   continent  country  province || feature1 feature2
         1   Europe     -        -        || false    true
         2   Europe     France   -        || true     -
         3   America    US       -        || false    false
@@ -214,7 +214,7 @@ defmodule Tablex.CodeGenerateTest do
     test "works" do
       table =
         Tablex.new("""
-        M   target.country  target.province || Feature1 Feature2
+        M   target.country  target.province || feature1 feature2
         1   Canada          BC,ON           || -        true
         2   Canada          -               || true     false
         """)
@@ -266,7 +266,7 @@ defmodule Tablex.CodeGenerateTest do
     test "works" do
       table =
         Tablex.new("""
-        M   target.country  target.province || Feature1.enabled
+        M   target.country  target.province || feature1.enabled
         1   Canada          BC,ON           || -
         2   Canada          -               || true
         """)

--- a/test/tablex/formatter_test.exs
+++ b/test/tablex/formatter_test.exs
@@ -8,7 +8,7 @@ defmodule Tablex.FormatterTest do
     test "works" do
       table =
         Tablex.new("""
-        F   Day (string)                         Weather (string) || Activity
+        F   day (string)                         weather (string) || activity
         1   Monday,Tuesday,Wednesday,Thursday    rainy            || read
         2   Monday,Tuesday,Wednesday,Thursday    -                || read,walk
         3   Friday                               sunny            || soccer
@@ -23,7 +23,7 @@ defmodule Tablex.FormatterTest do
     test "works with informative rows" do
       table =
         Tablex.new("""
-        F   Day                                  Weather          || Activity
+        F   day                                  weather          || activity
             (string, weekday)                    -                || -
         1   Monday,Tuesday,Wednesday,Thursday    rainy            || read
         2   Monday,Tuesday,Wednesday,Thursday    -                || read,walk
@@ -66,18 +66,18 @@ defmodule Tablex.FormatterTest do
             path: [:quest, :brand]
           },
           %Tablex.Variable{
-            name: :picking_only,
+            name: :pickingOnly,
             label: "quest.pickingAndDelivery.pickingOnly",
             desc: "Picking-only?",
             type: :bool,
-            path: [:quest, :picking_and_delivery]
+            path: [:quest, :pickingAndDelivery]
           },
           %Tablex.Variable{
-            name: :delivery_type,
+            name: :deliveryType,
             label: "quest.pickingAndDelivery.deliveryType",
             desc: "Delivery Type",
             type: :string,
-            path: [:quest, :picking_and_delivery]
+            path: [:quest, :pickingAndDelivery]
           },
           %Tablex.Variable{
             name: :type,

--- a/test/tablex/parser/variable_test.exs
+++ b/test/tablex/parser/variable_test.exs
@@ -6,26 +6,29 @@ defmodule Tablex.Parser.VariableTest do
   doctest Variable
 
   test "it works" do
-    assert %{name: :f, label: "F"} = parse("F")
+    assert %{name: :F, label: "F"} = parse("F")
   end
 
   test "it works for multi-letter char" do
-    assert %{name: :test, label: "Test"} = parse("Test")
+    assert %{name: :Test, label: "Test"} = parse("Test")
   end
 
-  test "it underscores" do
-    assert %{name: :test_foo} = parse("TestFoo")
-    assert %{name: :test_foo} = parse("Test-Foo")
-    assert %{name: :test_foo} = parse("Test-_Foo")
+  describe "Variable name cases" do
+    test "are kept" do
+      assert %{name: :TestFoo} = parse("TestFoo")
+      assert %{name: :Test_Foo} = parse("Test-Foo")
+      assert %{name: :Test__Foo} = parse("Test-_Foo")
+      assert %{name: :Test__Foo, path: [:myBar]} = parse("myBar.Test-_Foo")
+    end
   end
 
   test "it works with string type" do
-    assert %{name: :test, type: :string} = parse("Test (string)")
+    assert %{name: :Test, type: :string} = parse("Test (string)")
   end
 
   test "it works with descriptions" do
     assert %{
-             name: :test,
+             name: :Test,
              label: "Test",
              type: :string,
              desc: "describing the test"
@@ -34,7 +37,7 @@ defmodule Tablex.Parser.VariableTest do
 
   test "it works with quoted strings" do
     assert %{
-             name: :test_var_test,
+             name: :Test__var_test,
              label: "Test  var test",
              type: :string,
              desc: "describing the test"

--- a/test/tablex/parser_test.exs
+++ b/test/tablex/parser_test.exs
@@ -4,7 +4,7 @@ defmodule Tablex.ParserTest do
 
   test "basic parser" do
     box = """
-    F   Day (string)    Weather (string) || Activity
+    F   day (string)    weather (string) || activity
     1   Monday,Tuesday  sunny            || walk
     """
 
@@ -24,7 +24,7 @@ defmodule Tablex.ParserTest do
   describe "Multiple rules" do
     test "work" do
       box = """
-      F   Day (string)    Weather (string) || Activity
+      F   day (string)    weather (string) || activity
       1   Monday,Tuesday  sunny            || walk
       2   Monday,Tuesday  rainy            || read
       """

--- a/test/tablex/rules_test.exs
+++ b/test/tablex/rules_test.exs
@@ -38,8 +38,8 @@ defmodule Tablex.RulesTest do
                inputs: [
                  {[:store, :id], :any},
                  {[:quest, :brand, :id], :any},
-                 {[:quest, :picking_and_delivery, :picking_only], :any},
-                 {[:quest, :picking_and_delivery, :delivery_type], :any},
+                 {[:quest, :pickingAndDelivery, :pickingOnly], :any},
+                 {[:quest, :pickingAndDelivery, :deliveryType], :any},
                  {[:quest, :type], :any}
                ],
                outputs: [{[:enabled], false}]
@@ -49,8 +49,8 @@ defmodule Tablex.RulesTest do
                inputs: [
                  {[:store, :id], :any},
                  {[:quest, :brand, :id], 719},
-                 {[:quest, :picking_and_delivery, :picking_only], :any},
-                 {[:quest, :picking_and_delivery, :delivery_type], :any},
+                 {[:quest, :pickingAndDelivery, :pickingOnly], :any},
+                 {[:quest, :pickingAndDelivery, :deliveryType], :any},
                  {[:quest, :type], :any}
                ],
                outputs: [{[:enabled], true}]
@@ -60,8 +60,8 @@ defmodule Tablex.RulesTest do
                inputs: [
                  {[:store, :id], :any},
                  {[:quest, :brand, :id], [719, 749]},
-                 {[:quest, :picking_and_delivery, :picking_only], :any},
-                 {[:quest, :picking_and_delivery, :delivery_type], :any},
+                 {[:quest, :pickingAndDelivery, :pickingOnly], :any},
+                 {[:quest, :pickingAndDelivery, :deliveryType], :any},
                  {[:quest, :type], :any}
                ],
                outputs: [{[:enabled], true}]


### PR DESCRIPTION
We no longer automatically underscore variable names and path segments.